### PR TITLE
Add new resource page "Join Us on Slack"

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -38,3 +38,5 @@
     url: 2018/09/12/Travel-Grants.html
   - name: Graduate Student Petitions
     url: grad-petitions
+  - name: Join us on Slack!
+    url: join-on-slack

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,9 +14,8 @@
                 <div class="lead">
                     {{site.data.what_we_do.description | markdownify}}
                 </div>
-                
-                <a class="btn btn-accent btn-block" href="{{site.slack-signup}}" target="_blank">
-                    <i class="fa fa-slack" aria-hidden="true"></i> Join on Slack
+                <a class="btn btn-accent btn-block" href="/join-on-slack">
+                    <i class="fa fa-slack" aria-hidden="true"></i> Join us on Slack
                 </a>
             </div>
         </div>

--- a/handbook.md
+++ b/handbook.md
@@ -222,7 +222,7 @@ Contact her at:
 The handbook is the Computer Science department supplement to the [Graduate School policies and procedures](https://www.colorado.edu/graduateschool/current-students/graduate-school-policies-and-procedures). At writing, the Graduate school policies covered
 
 - Graduate School Rules
-- Concurrent Bachelor's/Master's degree program guidelines 
+- Concurrent Bachelor's/Master's degree program guidelines
 - Graduate School Grievance Policy
     * Appeal Form
 - Graduate Student Bill of Rights and Responsibilities

--- a/index.md
+++ b/index.md
@@ -6,5 +6,3 @@ layout: base
 {%include weekly.html %}
 {%include newsletter.html %}
 {%include carousel.html %}
-
-

--- a/join-on-slack.md
+++ b/join-on-slack.md
@@ -1,0 +1,22 @@
+---
+layout: page
+title: Join us on Slack!
+---
+
+We also use Slack for collaboration, sharing joy and ideas, and to support each other as a community.
+If you are a graduate student in the  Computer Science Department at University of Colorado Boulder, join us on slack.
+
+**Already joined?**
+
+<a class="btn btn-accent btn-block" href="https://boulder-cs-grads.slack.com" target="_blank">
+    <i class="fa fa-slack" aria-hidden="true"></i> Go to CSGSA Slack
+</a>
+
+**Haven't joined? Here's how to join:**
+
+We try and add all the incoming students before the start of the semester through an onboarding, but if that hasn't happened with you, you can request to get added in two ways.
+
+1. Send an email to [csgsa@colorado.edu](mailto:csgsa@colorado.edu) from your *@colorado.edu* email.
+2. Request a friend in the department to request to add you to the Slack Workspace. They can refer to [this](https://slack.com/help/articles/201330256-Invite-new-members-to-your-workspace) article on how to do it.
+
+We are very excited to have you, so we will make sure to respond to the  request in a timely manner.


### PR DESCRIPTION
## Description
Added new resource page Join Us on Slack
Can be arrived from the resources and FAQ dropdown or the home page or
Join on Slack button from the home page.

## Some questions
- [x] I read the contributing guidelines
- [ ] I'm adding a new event/footer link
- [ ] I'm editing an existing event/footer link
- [x] I'm adding a new feature/fixing a bug

If you answered No to question 1, go back and read the [instructions](.github/CONTRIBUTING.md) carefully.

## Additional Notes
None.