### PR TITLE
Add Spring21 GradSERU survey link in QOL

### DIFF
--- a/quality_of_life.md
+++ b/quality_of_life.md
@@ -3,13 +3,20 @@ layout: page
 title: Quality of Life
 ---
 
+## Graduate and Professional Students Survey - Spring 2021
+In Spring 2021, more than 5000 Graduate and Professional of CU Boulder students were invited to participate in the **gradSERU** survey.
+
+You can explore the results [here](https://public.tableau.com/views/gradSERUPublic2021Colorado/STARTHERE?%3AshowVizHome=no).
+
+Note: You can use the supported filters to explore department specific responses in each topic.
+
 ## Survey
- 
-In Spring 2018, before we'd even had our kickoff event, the Graduate Committee approached the CSGSA about hosting a “Climate Survey” to assess the social climate of the department. The last climate survey was done in 2014 and was for the whole graduate school. You can read about it [here](https://www.colorado.edu/oda/institutional-research/surveys/social-climate-surveys/graduate-student-social-climate-survey). 
+
+In Spring 2018, before we'd even had our kickoff event, the Graduate Committee approached the CSGSA about hosting a “Climate Survey” to assess the social climate of the department. The last climate survey was done in 2014 and was for the whole graduate school. You can read about it [here](https://www.colorado.edu/oda/institutional-research/surveys/social-climate-surveys/graduate-student-social-climate-survey).
 
 The Graduate Committee was naturally interested in fresher results that would focus more on the strengths and weaknesses of this department.  We also thought it would be a great way identify focus areas for the CSGSA to work on.  We decided to call it a “Quality-of-Life” survey to avoid any confusion about weather.
 
-69 students responded to the survey, 27 Masters students, and 42 PhD students. You can read the detailed survey summary 
+69 students responded to the survey, 27 Masters students, and 42 PhD students. You can read the detailed survey summary
 
 - [Climate Survey Summary]({% post_url 2018-03-28-Quality-of-Life-Survey-Summary%})
 
@@ -19,13 +26,14 @@ Or the departments response to the top 15 issues
 
 The CSGSA is still working on how best to address the issues raised in the survey and support the departments efforts. Join the #qualityoflife [Slack](https://boulder-cs-grads.slack.com/) channel to share ideas and raise issues.
 
+
 ## Graduate Student Town Hall
 
 Graduate Student Town Hall occurs once per semester. It is a venue for graduate students to share their concerns with the department, ask questions, and give suggestions directly to the department chair, graduate committee, and graduate advisor. Past town halls inspired the graduate student Slack, the CSGSA, and demand-based course scheduling.
 
 Check the [Calendar](calendar.bouldercsgrads.org) for the next Town Hall date.
 
-### Minutes 
+### Minutes
 
 - [Town Hall Fall 2017](2018/04/09/Graduate-Student-Town-Hall-2017-Summary-and-Outcomes.html)
 - [Town Hall Spring 2018](2018/10/01/Town-Hall-Minutes-Spring-2018.html)
@@ -33,6 +41,6 @@ Check the [Calendar](calendar.bouldercsgrads.org) for the next Town Hall date.
 
 ## Diversity and Inclusion Committee
 
-As of spring 2019, the CSGSA has formed a new Diversity and Inclusion Committee. We are working on issues like student financial stability, better reporting for bias related issues, providing workshops for students, faculty and staff, and a more inclusive admissions pipeline. 
+As of spring 2019, the CSGSA has formed a new Diversity and Inclusion Committee. We are working on issues like student financial stability, better reporting for bias related issues, providing workshops for students, faculty and staff, and a more inclusive admissions pipeline.
 
 We meet every other Thursday at 10 am in ECCR 1B10 (in the faculty office hallway next to the Systems Lab). Email csgsa@colorado.edu for the next meeting date. You can also join us online in the [#qualityoflife Slack channel](https://boulder-cs-grads.slack.com/#qualityoflife)


### PR DESCRIPTION
## Description
Added text and link to the Spring21 GradSERU survey dashboard

## Some questions
- [x] I read the contributing guidelines
- [ ] I'm adding a new event/footer link
- [ ] I'm editing an existing event/footer link
- [ ] I'm adding a new feature/fixing a bug

If you answered No to question 1, go back and read the [instructions](.github/CONTRIBUTING.md) carefully.

## Additional Notes
We probably need to archive older stuff and update the page. 
Adding an item to my list.