### PR TITLE
updated alumni sorted, hidden neural net, stipend update

### DIFF
--- a/_data/menu.yml
+++ b/_data/menu.yml
@@ -17,6 +17,7 @@
 
 - name: The Neural Network
   url: /neural-network
+  visible: hide 
 
 - name: Resources and FAQ
   subcategories:

--- a/_data/officers.yml
+++ b/_data/officers.yml
@@ -3,8 +3,8 @@
 chair:
     name: James Luther
     contact: James.Luther
-    photo: assets/img/officers/james_luther.jpg
-    pronouns: She/Her/Hers
+    photo: assets/img/officers/james_luther.jpeg
+    pronouns: He/Him/His
     bio: Jay Luther is a third-year Ph.D. student currently between advisors. He enjoys games of all kinds, reading, and hiking in the front range.
 
 vice_chair:
@@ -58,74 +58,96 @@ gpsg:
 alumni:
     - title: Chair
       people:
-          - name: Stephen Hutt
-            years: Spring 2018 - Fall 2019
-          - name: Jessie Finocchiaro
-            years: Spring 2019 - Fall 2020
+          - name: Maggie Perkoff
+            years: Spring 2022 - Fall 2022
           - name: Emily Jensen
             years: Spring 2020 - Fall 2021
+          - name: Jessie Finocchiaro
+            years: Spring 2019 - Fall 2020
+          - name: Stephen Hutt
+            years: Spring 2018 - Fall 2019
+          
+
+    - title: Vice Chair
+      people:
+          - name: Aishwarya Satwani 
+            years: Spring 2022 - Fall 2022
+
     - title: Treasurer
       people:
-          - name: Prasanth Prahladan
-            years: Fall 2018
-          - name: Yash Sapra
-            years: Spring - Fall 2019
-          - name: Dylan Fox
-            years: Spring 2019 - Fall 2020
+          - name: Neerab Kumar Pathipaka
+            years: Spring 2022 - Fall 2022
           - name: Caleb Escobedo
             years: Spring 2020 - Fall 2021
+          - name: Dylan Fox
+            years: Spring 2019 - Fall 2020
+          - name: Yash Sapra
+            years: Spring - Fall 2019
+          - name: Prasanth Prahladan
+            years: Fall 2018
 
     - title: CSGSA Anti-racism and Inclusion Chair
       people:
+          - name: Evariste Some
+            years: Spring 2022 - Fall 2022
           - name: Christine Chang
             years: Spring 2020 - Fall 2021
 
     - title: Graduate Committee
       people:
+          - name: Vinitha Gadiraju
+            years: Fall 2021 - Summer 2022
+          - name: Owen Martin
+            years: Fall 2021 - Summer 2022
+          - name: Nikith Sannidhi
+            years: Fall 2021 - Summer 2022
+          - name: Max Donavan
+            years: Fall 2021 - Summer 2022
+          - name: Amit Rege
+            years: 2020 - Spring 2021
+          - name: Varsha Koushik
+            years: 2020 - Spring 2021
+          - name: Evariste Some
+            years: 2020 - Spring 2021
+          - name: Arjun Rao
+            years: 2019 - Spring 2021
+          - name: Emily Jensen
+            years: 2019-2020
           - name: Prashil Bhimani
             years: 2018-2019
           - name: John Stechschulte
             years: 2017-2019
           - name: Stephen Hutt
             years: 2017-2019
-          - name: Emily Jensen
-            years: 2019-2020
-          - name: Arjun Rao
-            years: 2019 - Spring 2021
-          - name: Evariste Some
-            years: 2020 - Spring 2021
-          - name: Varsha Koushik
-            years: 2020 - Spring 2021
-          - name: Amit Rege
-            years: 2020 - Spring 2021
-          - name: Max Donavan
-            years: Fall 2021 - Summer 2022
-          - name: Nikith Sannidhi
-            years: Fall 2021 - Summer 2022
-          - name: Owen Martin
-            years: Fall 2021 - Summer 2022
-          - name: Vinitha Gadiraju
-            years: Fall 2021 - Summer 2022
+          
+          
 
     - title: Executive Committee
       people:
-          - name: Cecilia Mauceri
-            years: 2017-2019
-          - name: Layne Hubbard
-            years: 2019-2021
           - name: Namratha Mysore Keshavaprakash
             years: 2021-2022
+          - name: Layne Hubbard
+            years: 2019-2021
+          - name: Cecilia Mauceri
+            years: 2017-2019
+
 
     - title: GPSG Student Representative
       people:
-          - name: Jay Luther
-            years: Fall 2020 - Spring 2021
-          - name: Megan Caruso
-            years: Fall 2021
+          - name: Nikhil Hulle
+            years: Fall 2022
           - name: Naga Sai Meenakshi Sistla
             years: Spring 2022
+          - name: Megan Caruso
+            years: Fall 2021
+          - name: Jay Luther
+            years: Fall 2020 - Spring 2021
+
 
     - title: Web Guru
       people:
+          - name: Abhishek Purushothama
+            years: Fall 2021 - Fall 2022
           - name: Gerard Casas
             years: Spring 2018
+

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -19,7 +19,7 @@
 			<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
 				<ul class="nav navbar-nav navbar-right">
 					{% for link in site.data.menu %}		
-						{%if link.subcategories%}
+						{%if link.visible != "hide" and link.subcategories%}
 							<li class="dropdown">
 									<a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
 										{{ link.name|upcase }}	
@@ -37,7 +37,9 @@
 							</li>
 
 						{%else%}
+							{%if link.visible != "hide" %}
 							<li><a href="{{ link.url|relative_url}}">{{ link.name|upcase }}</a></li>
+							{%endif%}
 						{%endif%}
 					{%endfor%}
 				</ul>

--- a/_posts/2018-07-02-CS-Graduate-Student-Jobs.md
+++ b/_posts/2018-07-02-CS-Graduate-Student-Jobs.md
@@ -22,7 +22,7 @@ text-align:right;
 <table>
   <tr>
     <th>Title</th>
-    <th>Pay (2018-2019)</th>
+    <th>Pay (2022-2023)</th>
     <th>Hours (hr/wk)</th>
     <th>Tuition Waiver</th>
     <th>Health Insurance</th>
@@ -31,60 +31,71 @@ text-align:right;
   </tr>
   <tr>
     <td>Research Assistant (RA) at 50% appointment </td>
-    <td>$12,324 / semester*</td>
+    <td>$13,885 / semester*</td>
     <td>20</td>
-    <td>X</td>
-    <td>X</td>
+    <td>	&#9989; </td>
+    <td>	&#9989; </td>
     <td>Do research</td>
     <td></td>
   </tr>
   <tr>
     <td>Teaching Assistant (TA) at 50% appointment </td>
-    <td>$12,324 / semester*</td>
+    <td>$13,885 / semester*</td>
     <td>20</td>
-    <td>X</td>
-    <td>X</td>
+    <td>	&#9989; </td>
+    <td>	&#9989; </td>
     <td>Teach recitation<br>Hold office hours<br>Grade</td>
     <td>Undergraduate Only</td>
   </tr>
   <tr>
-    <td>Graduate Student Staff (GSS)</td>
-    <td>$15 / hr</td>
+    <td>Course Manager (CM)</td>
+    <td>$25 / hr</td>
     <td>&lt;= 20**</td>
     <td></td>
     <td></td>
     <td>Responsibilities vary by course, but can include grading, administration and office hours. Will not include teaching recitation </td>
     <td>Both undergraduate and graduate classes</td>
   </tr>
+  <tr>
+    <td>Course Grader (CG)</td>
+    <td>$17 / hr</td>
+    <td>&lt;= 20**</td>
+    <td></td>
+    <td></td>
+    <td>Responsibilities vary by course, but can include grading, interview grading. Will not include teaching recitation </td>
+    <td>Both undergraduate and graduate classes</td>
+  </tr>
 </table>
 
-'*' This amount is distributed monthly. The fall semester has 4 months, and the spring semester has 5. So the monthly earnings are $3081 and $2465 respectively. Also, post proposal PhD students in the CS department get a raise to $13,053 / semester.
+'*' This amount is distributed monthly. The fall semester has 4 months, and the spring semester has 5. So the monthly earnings are $3471 and $2777 respectively. Also, post proposal PhD students in the CS department get a raise to $13,053 / semester.
 
-'**' GSS hours depend on course enrollment.
+'**' Course Manager and Course Grader hours depend on course enrollment.
 
 There are a few other rarer jobs, such as lead TA and graduate part time instructor (GPTI), but the above are the most common.
 
 ## How to get one of these jobs
 
-Rajshree sends out a survey about three months before each semester to look for TAs, and GSS for courses. She then works with the curriculum/TA sub-committee to try and match the respondents with available courses. You can also find out about courses that need TAs, GSS from Rajshree. For PhD students, your research advisor might occasionally ask you to TA their course.
+Rajshree sends out a survey about three months before each semester to look for TAs, and CM, CGs for courses. She then works with the curriculum/TA sub-committee to try and match the respondents with available courses. You can also find out about courses that need TAs, CM, CGs from Rajshree. For PhD students, your research advisor might occasionally ask you to TA their course.
 
-For upper-level courses, you need to have taken the course before or have relevant experience in order to qualify to be a TA or GSS.  
+For upper-level courses, you need to have taken the course before or have relevant experience in order to qualify to be a TA or CM, CGs.  
 
 Typically, TAs are assigned with the following priorities
 
 1. PhD students with funding commitment
 2. PhD students without funding commitment and MS students who have previously held TAs
-3. Outstanding GSS are also at times considered for TA positions, if needed.
+3. Outstanding CM, CGs are also at times considered for TA positions, if needed.
 
 At all priority levels, you must perform your TA duties well. Students who have previously held TA positions and underperformed do not get picked up again.  
 
-GSS positions mostly go to Masters students.
+CM, CG positions mostly go to Masters students.
 
 If you want an RA, you need to speak to a professor with research funding and convince them to hire you. For PhD students, the professor who funds your RA is typically your research advisor.
 
+<!-- might be used in future -->
+<div hidden> 
 ## How many hours will I get?
 
-Hours for GSS vary based on the enrollment in the courses, and are usually determined just before the start of the semester. In general, more students mean more available hours.
+Hours for CM, CGs vary based on the enrollment in the courses, and are usually determined just before the start of the semester. In general, more students mean more available hours.
 
 I went through the historical FCQs of courses being offered Fall 2018 to get an idea of past enrollment. Larger course size means more hours will be available. The department has been growing steadily for the past few years and interest in topics can vary, but the historical numbers can give you a rough idea of how many hours you might get.
 
@@ -276,6 +287,7 @@ I went through the historical FCQs of courses being offered Fall 2018 to get an 
     <td class="right_align">34</td>
   </tr>
 </table>
+</div>
 
 ## Maximum Hours
 

--- a/_posts/2018-07-02-CS-Graduate-Student-Jobs.md
+++ b/_posts/2018-07-02-CS-Graduate-Student-Jobs.md
@@ -26,6 +26,7 @@ text-align:right;
     <th>Hours (hr/wk)</th>
     <th>Tuition Waiver</th>
     <th>Health Insurance</th>
+    <th>Student Fees</th>
     <th>Example Duties</th>
     <th>Courses Taught</th>
   </tr>
@@ -33,6 +34,7 @@ text-align:right;
     <td>Research Assistant (RA) at 50% appointment </td>
     <td>$13,885 / semester*</td>
     <td>20</td>
+    <td>	&#9989; </td>
     <td>	&#9989; </td>
     <td>	&#9989; </td>
     <td>Do research</td>
@@ -44,6 +46,7 @@ text-align:right;
     <td>20</td>
     <td>	&#9989; </td>
     <td>	&#9989; </td>
+    <td>	&#9989; </td>
     <td>Teach recitation<br>Hold office hours<br>Grade</td>
     <td>Undergraduate Only</td>
   </tr>
@@ -51,6 +54,7 @@ text-align:right;
     <td>Course Manager (CM)</td>
     <td>$25 / hr</td>
     <td>&lt;= 20**</td>
+    <td></td>
     <td></td>
     <td></td>
     <td>Responsibilities vary by course, but can include grading, administration and office hours. Will not include teaching recitation </td>
@@ -62,12 +66,13 @@ text-align:right;
     <td>&lt;= 20**</td>
     <td></td>
     <td></td>
+    <td></td>
     <td>Responsibilities vary by course, but can include grading, interview grading. Will not include teaching recitation </td>
     <td>Both undergraduate and graduate classes</td>
   </tr>
 </table>
 
-'*' This amount is distributed monthly. The fall semester has 4 months, and the spring semester has 5. So the monthly earnings are $3471 and $2777 respectively. Also, post proposal PhD students in the CS department get a raise to $13,053 / semester.
+'*' This amount is distributed monthly. The monthly earnings is $3,085. Also, post proposal PhD students in the CS department get a raise to $3268/mo.
 
 '**' Course Manager and Course Grader hours depend on course enrollment.
 


### PR DESCRIPTION
- Added alumni officers and sorted them in reverse order based on the date, chair picture fix
- Neural nets page is hidden with an extra field
- Stipends of TA, RA, CM, and CGs are updated
- The number of hours section is hidden
 
![image](https://user-images.githubusercontent.com/25689898/226776208-cb696657-5b26-45d7-ad77-3f226033d7e4.png)
![image](https://user-images.githubusercontent.com/25689898/226776315-fd214e92-ea60-4def-9814-a2b308aea9ac.png)
![image](https://user-images.githubusercontent.com/25689898/226776364-59f3e005-f264-4205-9434-fae97f8207fb.png)
